### PR TITLE
Updated advanced-bundle-composition.md

### DIFF
--- a/labs/cloudbees-ci-casc/content/labs/advanced-bundle-composition.md
+++ b/labs/cloudbees-ci-casc/content/labs/advanced-bundle-composition.md
@@ -116,7 +116,7 @@ plugins:
 catalog:
   - "plugin-catalog.yaml"
 ```
-2. Next let's take a detailed look at the `base` bundle `jenkins.yaml` (also available on GitHub at https://github.com/cloudbees-days/parent-configuration-bundle/blob/main/jenkins.yaml):
+2. Next let's take a detailed look at the `base` bundle `jenkins.yaml` (also available on GitHub at https://github.com/cloudbees-days/parent-configuration-bundle/blob/main/jenkins.yaml) :
 ```yaml
 jenkins:
   authorizationStrategy: "cloudBeesRoleBasedAccessControl"


### PR DESCRIPTION
I have updated the URL for the parent bundle to exclude the parentheses and semicolon that originally redirected the user to a 404