### PR TITLE
Fix url for bundle.yaml

### DIFF
--- a/labs/cloudbees-ci-casc/content/labs/advanced-bundle-composition.md
+++ b/labs/cloudbees-ci-casc/content/labs/advanced-bundle-composition.md
@@ -103,7 +103,7 @@ items:
 
 Bundle inheritance allows you to easily share common configuration across numerous controllers. In this lab we will update your Ops controller bundle to extend a parent bundle providing common configuration and plugins to be shared across all of your organizations controllers. First we will review the contents of the parent `base` bundle that has already been set-up on Operations Center (and is also the default bundle) and then we will update your Ops controller bundle to use the `base` bundle as a parent bundle. The `base` bundle will include Jenkins configuration that enforces best practices across all of the controllers in the CloudBees CI cluster and to include specifying a common set of plugins to be used across all controllers.
 
-1. First we will take a look at the `bundle.yaml` for the `base` bundle (also available on GitHub at https://github.com/cloudbees-days/parent-configuration-bundle/blob/main/bundle.yaml):
+1. First we will take a look at the `bundle.yaml` for the `base` [bundle (also available on GitHub at https://github.com/cloudbees-days/parent-configuration-bundle/blob/main/bundle.yaml](https://github.com/cloudbees-days/parent-configuration-bundle/blob/main/bundle.yaml)):
 ```yaml
 apiVersion: "1"
 id: "base"


### PR DESCRIPTION
the url as is goes to https://github.com/cloudbees-days/parent-configuration-bundle/blob/main/bundle.yaml): and the user has to manually remove ): to make it work